### PR TITLE
#Feedback features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ A comprehensive intraday trading strategy implementation using Exponential Movin
 - **EMA Signal**: EMA(3) > EMA(10) with 0.1% tolerance buffer
 - **RSI Signal**: RSI(14) > 60 (configurable, optimized to 55 with buffer)
 - **Trend Filter**: Close > EMA(50) with 0.2% tolerance buffer
-- **Entry Price**: High of the entry candle
+- **Entry Price**: High of the entry candle (Untile high entry price is reached)
 
 #### Short Entry
 - **EMA Signal**: EMA(3) < EMA(10) with 0.1% tolerance buffer
 - **RSI Signal**: RSI(14) < 30 (configurable, optimized to 35 with buffer)
 - **Trend Filter**: Close < EMA(50) with 0.2% tolerance buffer
-- **Entry Price**: Low of last 5 minutes (1-minute candles)
+- **Entry Price**: Low of last 5 minutes (1-minute candles) (Untile low entry price is reached)
 
 ### Risk Management
 - **Base Capital**: ₹10,00,000 (configurable)
@@ -230,7 +230,7 @@ $env:DEBUG="true"
 
 ### Multi-Timeframe Architecture
 - **Primary Indicators**: EMA(3), EMA(10), RSI(14) calculated on 10-minute OHLC data
-- **Trend Filter**: EMA(50) calculated on 1-hour OHLC data, forward-filled to 10-minute intervals
+- **Trend Filter**: EMA(50) calculated on 1-hour OHLC data based on past 30 days of stock_data, forward-filled to 10-minute intervals
 - **Entry Precision**: Short entries use 1-minute data for precise low-of-last-5-minutes calculation
 
 ### Advanced Features


### PR DESCRIPTION
A) For backtesting data of EMA50, took the 30 days data collectively from stock_data and then do it.
B) For long/short entry position, one needs to wait until price is reached

## Summary by Sourcery

Load collective 30-day data for EMA50 calculation and delay trade entries until the target price is actually reached for both long and short signals

New Features:
- Load 30 days of historical data to calculate EMA50 on the 1-hour timeframe for all symbols
- Introduce pending trade entries that wait until price reaches the high/low of the signal candle before executing long/short positions

Enhancements:
- Merge EMA50 from the collective dataset into 10-minute data with fallback for missing symbols
- Reset pending entries upon execution or exit to avoid stale state

Documentation:
- Update README to document the waiting-until-price-reaches entry logic and the 30-day EMA50 computation